### PR TITLE
Fix section ref indices on HomePage

### DIFF
--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -49,25 +49,25 @@ const HomePage: React.FC = () => {
       </SectionWrapper>
 
       <SectionWrapper index={2}>
-        <div ref={(el) => setSectionRef(el, 5)}>
+        <div ref={(el) => setSectionRef(el, 2)}>
           <Projects />
         </div>
       </SectionWrapper>
 
       <SectionWrapper index={3}>
-        <div ref={(el) => setSectionRef(el, 2)}>
+        <div ref={(el) => setSectionRef(el, 3)}>
           <Skills />
         </div>
       </SectionWrapper>
 
       <SectionWrapper index={4}>
-        <div ref={(el) => setSectionRef(el, 3)}>
+        <div ref={(el) => setSectionRef(el, 4)}>
           <ContactMe />
         </div>
       </SectionWrapper>
 
       <SectionWrapper index={5}>
-        <div ref={(el) => setSectionRef(el, 4)}>
+        <div ref={(el) => setSectionRef(el, 5)}>
           <Title />
         </div>
       </SectionWrapper>


### PR DESCRIPTION
## Summary
- align setSectionRef calls with their corresponding SectionWrapper indices on the home page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0336233308331b7f6899e1d178366