### PR TITLE
Use media query hook safely

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,19 +3,17 @@ import HeaderMobile from "./HeaderMobile";
 import HeaderDesktop from "./HeaderDesktop";
 import useDarkMode from "@/hooks/useDarkMode";
 import useCurrentTime from "@/hooks/useCurrentTime";
+import useMediaQuery from "@/hooks/useMediaQuery";
 
 const Header: React.FC = () => {
   const { isDarkMode, toggleDarkMode } = useDarkMode();
   const formattedTime = useCurrentTime();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const isMobile = useMediaQuery("(max-width: 768px)");
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen);
   };
-
-
-  const isMobile = window.matchMedia("(max-width: 768px)").matches;
-
   return (
     <header
       className="top-0 left-0 z-50 sticky pt-[env(safe-area-inset-top)] w-full transition-colors duration-100 ease-in-out"

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,15 +1,24 @@
 // src/hooks/useMediaQuery.ts
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const useMediaQuery = (query: string): boolean => {
-  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+  const [matches, setMatches] = useState<boolean>(false);
 
   useEffect(() => {
-    const media = window.matchMedia(query);
-    const listener = () => setMatches(media.matches);
+    if (typeof window === "undefined") {
+      return undefined;
+    }
 
-    media.addEventListener("change", listener);
-    return () => media.removeEventListener("change", listener);
+    const mediaQueryList = window.matchMedia(query);
+
+    const updateMatches = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQueryList.matches);
+    mediaQueryList.addEventListener("change", updateMatches);
+
+    return () => mediaQueryList.removeEventListener("change", updateMatches);
   }, [query]);
 
   return matches;


### PR DESCRIPTION
## Summary
- guard the media query hook against missing window access and update matches inside the effect
- update the header component to rely on the media query hook for responsive rendering

## Testing
- pnpm build *(fails: data/data.json missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d033aad1888331bfc38335144f4b5a