### PR TITLE
Prevent resetting scroll when section saved

### DIFF
--- a/src/container/Routes.tsx
+++ b/src/container/Routes.tsx
@@ -17,8 +17,8 @@ export default function AppRoutes() {
         duration: 0.5,
         onComplete: () => {
           const savedIndex = localStorage.getItem("activeSection");
-          if (savedIndex && location.pathname === "/") {
-            const mainContainer = document.getElementById('main-container');
+          if (!savedIndex && location.pathname === "/") {
+            const mainContainer = document.getElementById("main-container");
             if (mainContainer) {
               mainContainer.scrollTo(0, 0);
             }


### PR DESCRIPTION
## Summary
- update the route transition onComplete callback to avoid forcing a scroll reset when a saved active section exists
- ensure the scroll reset only happens when landing on Home without a stored active section so navigation preserves the saved viewport

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d03821a06c83319b8d24706827688b